### PR TITLE
fix: remove extra location flags from chrome/safari presets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@qnaplus/node-curl-impersonate",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "A typescript wrapper around cURL-impersonate.",
     "main": "dist/index.js",
     "scripts": {

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -34,8 +34,7 @@ export const ChromePresets: Record<ChromePresetVersion, Preset> = {
             "--compressed",
             "--tlsv1.2",
             "--alps",
-            "--cert-compression brotli",
-            "--location"
+            "--cert-compression brotli"
         ]
     },
     "110": {
@@ -151,8 +150,7 @@ export const SafariPresets: Record<SafariPresetVersion, Preset> = {
             "--tlsv1.0",
             "--no-tls-session-ticket",
             "--cert-compression zlib",
-            "--http2-pseudo-headers-order mspa",
-            "--location"
+            "--http2-pseudo-headers-order mspa"
         ]
     }
 };


### PR DESCRIPTION
- Fixes a bug where the `--location` flag was present on the chrome107 preset and safari15.5 preset